### PR TITLE
Prevent infinite redirects when at root path

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -110,7 +110,7 @@ func (fs *fileServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Redirect to canonical path: / at end of directory url.
 	url := req.URL.Path
 	if fi.IsDir() {
-		if !strings.HasSuffix(url, "/") {
+		if !strings.HasSuffix(url, "/") && url != "" {
 			localRedirect(w, req, pathpkg.Base(url)+"/")
 			return
 		}

--- a/fs_test.go
+++ b/fs_test.go
@@ -1,6 +1,7 @@
 package httpgzip_test
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,6 +9,8 @@ import (
 	"time"
 
 	"github.com/shurcooL/httpgzip"
+	"golang.org/x/tools/godoc/vfs/httpfs"
+	"golang.org/x/tools/godoc/vfs/mapfs"
 )
 
 func ExampleFileServer() {
@@ -44,6 +47,36 @@ func TestServeContent_detectContentType(t *testing.T) {
 	got := resp.Header.Get("Content-Type")
 	want := "text/plain; charset=utf-8"
 	if got != want {
+		t.Errorf("got:\n%v\nwant:\n%v\n", got, want)
+	}
+}
+
+// Test that there are no infinite redirects at root path even if the entire
+// req.URL.Path is stripped, e.g., via an overly aggressive http.StripPrefix.
+// See https://github.com/shurcooL/httpgzip/pull/3
+// and https://github.com/golang/go/commit/3745716bc3940f471137bf06fbe8c042257a43d3.
+func TestFileServer_implicitLeadingSlash(t *testing.T) {
+	fs := httpfs.New(mapfs.New(map[string]string{
+		"foo.txt": "Hello world",
+	}))
+	ts := httptest.NewServer(http.StripPrefix("/bar/", httpgzip.FileServer(fs, httpgzip.FileServerOptions{})))
+	defer ts.Close()
+	get := func(suffix string) string {
+		res, err := http.Get(ts.URL + suffix)
+		if err != nil {
+			t.Fatalf("Get %s: %v", suffix, err)
+		}
+		defer res.Body.Close()
+		b, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("ReadAll %s: %v", suffix, err)
+		}
+		return string(b)
+	}
+	if got := get("/bar/"); !strings.Contains(got, ">foo.txt<") {
+		t.Errorf("got:\n%v\nwant a directory listing with foo.txt\n", got)
+	}
+	if got, want := get("/bar/foo.txt"), "Hello world"; got != want {
 		t.Errorf("got:\n%v\nwant:\n%v\n", got, want)
 	}
 }


### PR DESCRIPTION
I'm getting infinite redirects when I request the static files' root path. This fixes the problem.