### PR TITLE
add an option for directory listing, default disabled

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -28,6 +28,9 @@ var defaults = FileServerOptions{
 
 // FileServerOptions specifies options for FileServer.
 type FileServerOptions struct {
+	// DirListing controls whether a directory listing is shown for directories.
+	DirListing bool
+
 	// IndexHTML controls special handling of "index.html" file.
 	IndexHTML bool
 
@@ -141,6 +144,10 @@ func (fs *fileServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// A directory?
 	if fi.IsDir() {
 		if checkLastModified(w, req, fi.ModTime()) {
+			return
+		}
+		if !fs.opt.DirListing {
+			http.Error(w, "403 Forbidden", http.StatusForbidden)
 			return
 		}
 		err := dirList(w, f, path == "/")

--- a/fs_test.go
+++ b/fs_test.go
@@ -51,6 +51,30 @@ func TestServeContent_detectContentType(t *testing.T) {
 	}
 }
 
+// Test that no dir listing is shown if the DirListing option is false.
+func TestFileServer_noDirListing(t *testing.T) {
+	fs := httpfs.New(mapfs.New(map[string]string{
+		"foo.txt": "Hello world",
+	}))
+	ts := httptest.NewServer(http.StripPrefix("/bar/", httpgzip.FileServer(fs, httpgzip.FileServerOptions{})))
+	defer ts.Close()
+	res, err := http.Get(ts.URL + "/bar/")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer res.Body.Close()
+	if want := http.StatusForbidden; res.StatusCode != want {
+		t.Fatalf("got status %d, want %d", res.StatusCode, want)
+	}
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if want := "403 Forbidden\n"; string(b) != want {
+		t.Fatalf("got body %q, want %q", b, want)
+	}
+}
+
 // Test that there are no infinite redirects at root path even if the entire
 // req.URL.Path is stripped, e.g., via an overly aggressive http.StripPrefix.
 // See https://github.com/shurcooL/httpgzip/pull/3
@@ -59,7 +83,7 @@ func TestFileServer_implicitLeadingSlash(t *testing.T) {
 	fs := httpfs.New(mapfs.New(map[string]string{
 		"foo.txt": "Hello world",
 	}))
-	ts := httptest.NewServer(http.StripPrefix("/bar/", httpgzip.FileServer(fs, httpgzip.FileServerOptions{})))
+	ts := httptest.NewServer(http.StripPrefix("/bar/", httpgzip.FileServer(fs, httpgzip.FileServerOptions{DirListing: true})))
 	defer ts.Close()
 	get := func(suffix string) string {
 		res, err := http.Get(ts.URL + suffix)


### PR DESCRIPTION
Thanks for the great package!

This PR makes the directory listing feature require an explicit option `DirListing`. This prevents users from mistakenly enabling directory listings for assets, which could be bad for users wanting assets only to be accessible to end users who know the specific path names.

I think making this feature opt-in is better because this library describes itself as `provid[ing] net/http-like primitives`. The `net/http` package's `FileServer` type does not provide directory listings, and directory listings are arguably not a "primitive".